### PR TITLE
explicitly install rustup components in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,8 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - run: rustup component add rustfmt
+          profile: minimal
+          components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -55,7 +56,8 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - run: rustup component add clippy
+          profile: minimal
+          components: clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
           override: true
       - run: rustup component add rustfmt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
           override: true
       - run: rustup component add clippy


### PR DESCRIPTION
using the minimal profile causes the build to fail if the latest version of nightly compiler doesn't have corresponding tools available